### PR TITLE
Feature/pyproject.toml and docker-compose.yml improved.

### DIFF
--- a/{{cookiecutter.project_slug}}/docker-compose.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     container_name: {{cookiecutter.project_slug}}_test
     image: cloudblueconnect/connect-extension-runner:24.6
     working_dir: /extension
-    command: /bin/bash -c "poetry install && pytest --verbose --cov={{cookiecutter.package_slug}} --cov-report=html --cov-report=term-missing:skip-covered"
+    command: /bin/bash -c "poetry install && poetry run pytest"
     volumes:
       - .:/extension
     env_file:

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -22,7 +22,7 @@ pytest-cov = "^2.10.1"
 pytest-mock = "^3.3.1"
 pytest-asyncio = "^0.15.1"
 pytest-httpx = "^0.12.0"
-coverage = {extras = ["toml"], version = "^5.3"}
+coverage = { extras = ["toml"], version = "^5.3" }
 responses = "^0.12.0"
 flake8 = "~3.8"
 flake8-bugbear = "~20"
@@ -46,6 +46,7 @@ testpaths = "tests"
 addopts = "--cov={{ cookiecutter.package_slug }} --cov-report=term-missing:skip-covered --cov-report=html --cov-report=xml"
 
 [tool.coverage.run]
+relative_files = true
 branch = true
 
 [tool.coverage.report]


### PR DESCRIPTION
* Added `relative_files` option to ease the process of the coverage report in external systems (check https://coverage.readthedocs.io/en/6.3.1/config.html#run for more details).
* Test container now uses poetry to run `pytest`, so the single point of configuration for the test execution is the `pyproject.toml` file, previously the test options should be configured in two files, `pyproject.toml` and `docker-compose.yml` file.